### PR TITLE
[Refactor] Use custom timers instead of classic java timers

### DIFF
--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/DifficultyDeathScaler.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/DifficultyDeathScaler.java
@@ -77,12 +77,9 @@ public class DifficultyDeathScaler implements ModInitializer {
 
         ServerLifecycleEvents.SERVER_STOPPING.register(server -> {
             difficultyManager.save();
-            difficultyManager.stop();
             playerDifficultyManagerMap.forEach((player, manager) -> {
                 manager.save();
-                manager.stop();
             });
-            bountyMap.forEach((player, bounty) -> bounty.stop());
         });
 
         ServerLivingEntityEvents.AFTER_DEATH.register((entity, damageSource) -> {
@@ -116,7 +113,7 @@ public class DifficultyDeathScaler implements ModInitializer {
 
             difficultyManager.applyModifiers(handler.player);
 
-            final var bounty = Bounty.newBounty(difficultyManager, playerDifficulty);
+            final var bounty = Bounty.newBounty(server, difficultyManager, playerDifficulty);
             if (bounty != null) bountyMap.put(handler.player.getUuid(), bounty);
         });
 

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyData.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyData.java
@@ -1,0 +1,8 @@
+package world.anhgelus.architectsland.difficultydeathscaler.difficulty;
+
+public class DifficultyData {
+    public int deaths = 0;
+    public long timeBeforeReduce = 0;
+    public int totalOfDeath = 0;
+    public long secondsLowerDifficulty = 0;
+}

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
@@ -8,6 +8,7 @@ import net.minecraft.util.Pair;
 import net.minecraft.world.GameRules;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import world.anhgelus.architectsland.difficultydeathscaler.DifficultyDeathScaler;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.modifier.Modifier;
 import world.anhgelus.architectsland.difficultydeathscaler.timer.TickTask;
 import world.anhgelus.architectsland.difficultydeathscaler.timer.TimerAccess;
@@ -125,8 +126,10 @@ public abstract class DifficultyManager extends DifficultyTimer {
      */
     public void setNumberOfDeath(int n, boolean silent) {
         numberOfDeath = n;
+        DifficultyDeathScaler.LOGGER.info("before update death: {}", this);
         if (silent) updateDeath(UpdateType.SILENT);
         else updateDeath(UpdateType.SET);
+        DifficultyDeathScaler.LOGGER.info("before update timer task: {}", this);
         updateTimerTask();
     }
 
@@ -146,7 +149,7 @@ public abstract class DifficultyManager extends DifficultyTimer {
     }
 
     public void updateTimerTask() {
-        if (reducerTask != null) reducerTask.cancel();
+        if (reducerTask != null && !reducerTask.isCancelled()) reducerTask.cancel();
         if (numberOfDeath == 0) return;
         timerStart = System.currentTimeMillis() / 1000;
         reducerTask = executeTask(() -> {

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
@@ -26,6 +26,9 @@ public abstract class DifficultyManager extends DifficultyTimer {
 
     protected int numberOfDeath;
 
+    protected long secondsLowerDifficulty;
+    protected TimerAccess.TickTask secondsLowerDifficultyCounterTask;
+
     protected DifficultyManager(MinecraftServer server, Step[] steps, long secondsBeforeDecreased) {
         timer = TimerAccess.getTimerFromOverworld(server);
         this.server = server;
@@ -150,15 +153,19 @@ public abstract class DifficultyManager extends DifficultyTimer {
 
     public void updateTimerTask() {
         if (reducerTask != null && reducerTask.isRunning()) reducerTask.cancel();
-        if (numberOfDeath == 0) return;
-        timerStart = System.currentTimeMillis() / 1000;
+        if (numberOfDeath == 0) {
+            secondsLowerDifficulty = 0;
+            secondsLowerDifficultyCounterTask = new TickTask(() -> {
+                if (numberOfDeath > 0 && secondsLowerDifficultyCounterTask.isRunning())
+                    secondsLowerDifficultyCounterTask.cancel();
+                secondsLowerDifficulty++;
+            }, 20, 20);
+            timer.dds_runTask(secondsLowerDifficultyCounterTask);
+            return;
+        }
         reducerTask = executeTask(() -> {
-            timerStart = System.currentTimeMillis() / 1000;
             decreaseDeath();
-            if (numberOfDeath == 0) {
-                reducerTask.cancel();
-                timerStart = -1;
-            }
+            if (numberOfDeath == 0) reducerTask.cancel();
         }, reducerTask, secondsBeforeDecreased);
     }
 
@@ -167,6 +174,7 @@ public abstract class DifficultyManager extends DifficultyTimer {
         // Prevents for example the difficulty decrease message when killing a boss if the difficulty doesn't decrease.
         if (numberOfDeath < steps[1].level()) {
             numberOfDeath = 0;
+            updateTimerTask();
             return;
         }
 
@@ -286,7 +294,7 @@ public abstract class DifficultyManager extends DifficultyTimer {
             sb.append("§r to make the difficulty decrease.");
         } else if (numberOfDeath == steps[1].level()) {
             sb.append("You were on the lowest difficulty for §6")
-                    .append(formatSeconds(System.currentTimeMillis() / 1000 - timerStart))
+                    .append(formatSeconds(secondsLowerDifficulty))
                     .append("§r, but you had to die and ruin everything, hadn't you?");
         } else {
             sb.append("If ").append(beginning).append(" for §6")

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
@@ -17,7 +17,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
 public abstract class DifficultyManager extends DifficultyTimer {
-    private TickTask reducerTask;
+    protected TickTask reducerTask;
 
     protected final long secondsBeforeDecreased;
 
@@ -149,7 +149,7 @@ public abstract class DifficultyManager extends DifficultyTimer {
     }
 
     public void updateTimerTask() {
-        if (reducerTask != null && !reducerTask.isCancelled()) reducerTask.cancel();
+        if (reducerTask != null && reducerTask.isRunning()) reducerTask.cancel();
         if (numberOfDeath == 0) return;
         timerStart = System.currentTimeMillis() / 1000;
         reducerTask = executeTask(() -> {

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
@@ -12,8 +12,8 @@ import world.anhgelus.architectsland.difficultydeathscaler.difficulty.modifier.M
 import world.anhgelus.architectsland.difficultydeathscaler.timer.TickTask;
 import world.anhgelus.architectsland.difficultydeathscaler.timer.TimerAccess;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
 
 public abstract class DifficultyManager extends DifficultyTimer {
     protected TickTask reducerTask;
@@ -65,7 +65,7 @@ public abstract class DifficultyManager extends DifficultyTimer {
 
     @FunctionalInterface
     public interface Reached {
-        void reached(MinecraftServer server, GameRules gamerules, Updater updater);
+        void reached(MinecraftServer server, GameRules gamerules, DifficultyUpdater updater);
     }
 
     public static final class Step extends Pair<Integer, Reached> {
@@ -77,47 +77,8 @@ public abstract class DifficultyManager extends DifficultyTimer {
             return getLeft();
         }
 
-        public void reached(MinecraftServer server, GameRules rules, Updater updater) {
+        public void reached(MinecraftServer server, GameRules rules, DifficultyUpdater updater) {
             getRight().reached(server, rules, updater);
-        }
-    }
-
-    public static final class Updater {
-        private int difficultyLevel = 1;
-
-        private final Map<Class<? extends Modifier<?>>, Modifier<?>> map = new HashMap<>();
-
-        public void updateDifficulty(int level) {
-            if (level > difficultyLevel) {
-                difficultyLevel = level;
-            }
-        }
-
-        public Modifier<?> getModifier(Class<? extends Modifier<?>> clazz) {
-            var val = map.get(clazz);
-            if (val != null) return val;
-            try {
-                val = clazz.getConstructor().newInstance();
-            } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
-                     NoSuchMethodException e) {
-                throw new RuntimeException(e);
-            }
-            map.put(clazz, val);
-            return val;
-        }
-
-        public List<Modifier<?>> getModifiers() {
-            return new ArrayList<>(map.values());
-        }
-
-        public net.minecraft.world.Difficulty getDifficulty() {
-            return switch (difficultyLevel) {
-                case 0 -> net.minecraft.world.Difficulty.PEACEFUL;
-                case 1 -> net.minecraft.world.Difficulty.EASY;
-                case 2 -> net.minecraft.world.Difficulty.NORMAL;
-                case 3 -> net.minecraft.world.Difficulty.HARD;
-                default -> throw new IllegalArgumentException("Difficulty level out of range: " + difficultyLevel);
-            };
         }
     }
 
@@ -198,13 +159,13 @@ public abstract class DifficultyManager extends DifficultyTimer {
         onUpdate(updateType, updater);
     }
 
-    protected Updater getUpdater() {
-        final var updater = new Updater();
+    protected DifficultyUpdater getUpdater() {
+        final var updater = new DifficultyUpdater();
         getUpdatedSteps(updater);
         return updater;
     }
 
-    protected void getUpdatedSteps(Updater updater) {
+    protected void getUpdatedSteps(DifficultyUpdater updater) {
         final var rules = server.getGameRules();
 
         var i = 0;
@@ -224,9 +185,9 @@ public abstract class DifficultyManager extends DifficultyTimer {
         return generateDifficultyUpdate(null, difficulty);
     }
 
-    protected abstract void onUpdate(UpdateType updateType, Updater updater);
+    protected abstract void onUpdate(UpdateType updateType, DifficultyUpdater updater);
 
-    protected void onDeath(UpdateType updateType, Updater updater) {
+    protected void onDeath(UpdateType updateType, DifficultyUpdater updater) {
     }
 
     /**
@@ -257,7 +218,7 @@ public abstract class DifficultyManager extends DifficultyTimer {
     }
 
     protected List<Modifier<?>> getModifiers(int level) {
-        final var updater = new Updater();
+        final var updater = new DifficultyUpdater();
         for (final Step step : steps) {
             if (step.level() <= level) step.reached(server, server.getGameRules(), updater);
             else break;
@@ -265,7 +226,7 @@ public abstract class DifficultyManager extends DifficultyTimer {
         return updater.getModifiers();
     }
 
-    protected void updateModifiersValue(Updater updater) {
+    protected void updateModifiersValue(DifficultyUpdater updater) {
         updateModifiersValue(updater.getModifiers());
     }
 

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
@@ -277,16 +277,17 @@ public abstract class DifficultyManager extends DifficultyTimer {
         } else if (updateType == UpdateType.AUTOMATIC_INCREASE) {
             sb.append("The difficulty is increasing automatically!");
         } else if (updateType != UpdateType.INCREASE) {
-            sb.append("You only need to survive for §6")
-                    .append(formatSeconds(secondsBeforeDecreased - System.currentTimeMillis() / 1000 + timerStart))
-                    .append("§r to make the difficulty decrease.");
-        } else if (numberOfDeath < steps[2].level()) {
+            sb.append("You only need to survive for §6");
+            if (updateType == UpdateType.SET) sb.append(formatSeconds(secondsBeforeDecreased));
+            else sb.append(formatSecondsBeforeRun(reducerTask));
+            sb.append("§r to make the difficulty decrease.");
+        } else if (numberOfDeath == steps[1].level()) {
             sb.append("You were on the lowest difficulty for §6")
                     .append(formatSeconds(System.currentTimeMillis() / 1000 - timerStart))
                     .append("§r, but you had to die and ruin everything, hadn't you?");
         } else {
             sb.append("If ").append(beginning).append(" for §6")
-                    .append(formatSeconds(secondsBeforeDecreased - System.currentTimeMillis() / 1000 + timerStart))
+                    .append(formatSecondsBeforeRun(reducerTask))
                     .append("§r, then the difficulty would’ve decreased... But you chose your fate.");
         }
         sb.append("\n§8=============================================§r");

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
@@ -8,7 +8,6 @@ import net.minecraft.util.Pair;
 import net.minecraft.world.GameRules;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import world.anhgelus.architectsland.difficultydeathscaler.DifficultyDeathScaler;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.modifier.Modifier;
 import world.anhgelus.architectsland.difficultydeathscaler.timer.TickTask;
 import world.anhgelus.architectsland.difficultydeathscaler.timer.TimerAccess;
@@ -25,6 +24,7 @@ public abstract class DifficultyManager extends DifficultyTimer {
     protected final MinecraftServer server;
 
     protected int numberOfDeath;
+    protected int totalOfDeath = 0;
 
     protected long secondsLowerDifficulty;
     protected TimerAccess.TickTask secondsLowerDifficultyCounterTask;
@@ -129,10 +129,8 @@ public abstract class DifficultyManager extends DifficultyTimer {
      */
     public void setNumberOfDeath(int n, boolean silent) {
         numberOfDeath = n;
-        DifficultyDeathScaler.LOGGER.info("before update death: {}", this);
         if (silent) updateDeath(UpdateType.SILENT);
         else updateDeath(UpdateType.SET);
-        DifficultyDeathScaler.LOGGER.info("before update timer task: {}", this);
         updateTimerTask();
     }
 
@@ -242,7 +240,21 @@ public abstract class DifficultyManager extends DifficultyTimer {
 
     public abstract void applyModifiers(ServerPlayerEntity player);
 
-    public abstract void save();
+    protected void load(DifficultyData data) {
+        totalOfDeath = data.totalOfDeath;
+        secondsLowerDifficulty = data.secondsLowerDifficulty;
+        delayFirstTask(data.timeBeforeReduce);
+        setNumberOfDeath(data.deaths, true);
+    }
+
+    protected void save(DifficultyData data) {
+        data.deaths = numberOfDeath;
+        data.totalOfDeath = totalOfDeath;
+        data.secondsLowerDifficulty = secondsLowerDifficulty;
+        if (reducerTask != null && reducerTask.isRunning())
+            data.timeBeforeReduce = reducerTask.getTickingBeforeRun();
+        else data.timeBeforeReduce = 0;
+    }
 
     protected List<Modifier<?>> getModifiers(int level) {
         final var updater = new Updater();

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
@@ -9,12 +9,14 @@ import net.minecraft.world.GameRules;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.modifier.Modifier;
+import world.anhgelus.architectsland.difficultydeathscaler.timer.TickTask;
+import world.anhgelus.architectsland.difficultydeathscaler.timer.TimerAccess;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
 public abstract class DifficultyManager extends DifficultyTimer {
-    private TimerTask reducerTask;
+    private TickTask reducerTask;
 
     protected final long secondsBeforeDecreased;
 
@@ -24,7 +26,7 @@ public abstract class DifficultyManager extends DifficultyTimer {
     protected int numberOfDeath;
 
     protected DifficultyManager(MinecraftServer server, Step[] steps, long secondsBeforeDecreased) {
-        timer = new Timer();
+        timer = TimerAccess.getTimerFromOverworld(server);
         this.server = server;
         this.steps = steps;
         numberOfDeath = 0;
@@ -117,7 +119,8 @@ public abstract class DifficultyManager extends DifficultyTimer {
 
     /**
      * Set the number of death
-     * @param n number of death
+     *
+     * @param n      number of death
      * @param silent if the update is silent
      */
     public void setNumberOfDeath(int n, boolean silent) {
@@ -157,8 +160,14 @@ public abstract class DifficultyManager extends DifficultyTimer {
             }
         };
         timerStart = System.currentTimeMillis() / 1000;
-        executeTask(task, reducerTask, secondsBeforeDecreased);
-        reducerTask = task;
+        reducerTask = executeTask(() -> {
+            timerStart = System.currentTimeMillis() / 1000;
+            decreaseDeath();
+            if (numberOfDeath == 0) {
+                reducerTask.cancel();
+                timerStart = -1;
+            }
+        }, reducerTask, secondsBeforeDecreased);
     }
 
     public void decreaseDeath() {
@@ -171,7 +180,7 @@ public abstract class DifficultyManager extends DifficultyTimer {
 
         for (int i = steps.length - 1; i > 0; i--) {
             if (numberOfDeath >= steps[i].level()) {
-                numberOfDeath = steps[i-1].level();
+                numberOfDeath = steps[i - 1].level();
                 break;
             }
         }
@@ -219,10 +228,12 @@ public abstract class DifficultyManager extends DifficultyTimer {
 
     protected abstract void onUpdate(UpdateType updateType, Updater updater);
 
-    protected void onDeath(UpdateType updateType, Updater updater) {}
+    protected void onDeath(UpdateType updateType, Updater updater) {
+    }
 
     /**
      * Generate difficulty update
+     *
      * @param updateType Type of update (if null, it's a get and not an update)
      * @param difficulty Difficulty of the game
      * @return Message to print
@@ -250,7 +261,7 @@ public abstract class DifficultyManager extends DifficultyTimer {
 
     protected String generateHeaderUpdate(@Nullable UpdateType updateType) {
         final var sb = new StringBuilder();
-        if (updateType == null) sb.append( "§8============== §rCurrent difficulty: §8==============§r");
+        if (updateType == null) sb.append("§8============== §rCurrent difficulty: §8==============§r");
         else {
             switch (updateType) {
                 case INCREASE -> sb.append("§8============== §rDifficulty increase! §8==============§r");
@@ -272,22 +283,22 @@ public abstract class DifficultyManager extends DifficultyTimer {
 
         if (updateType == UpdateType.DECREASE) {
             sb.append("You only need to survive for §6")
-                .append(formatSeconds(secondsBeforeDecreased))
-                .append("§r to make the difficulty decrease again.");
+                    .append(formatSeconds(secondsBeforeDecreased))
+                    .append("§r to make the difficulty decrease again.");
         } else if (updateType == UpdateType.AUTOMATIC_INCREASE) {
             sb.append("The difficulty is increasing automatically!");
         } else if (updateType != UpdateType.INCREASE) {
             sb.append("You only need to survive for §6")
-                .append(formatSeconds(secondsBeforeDecreased - System.currentTimeMillis() / 1000 + timerStart))
-                .append("§r to make the difficulty decrease.");
+                    .append(formatSeconds(secondsBeforeDecreased - System.currentTimeMillis() / 1000 + timerStart))
+                    .append("§r to make the difficulty decrease.");
         } else if (numberOfDeath < steps[2].level()) {
             sb.append("You were on the lowest difficulty for §6")
-                .append(formatSeconds(System.currentTimeMillis() / 1000 - timerStart))
-                .append("§r, but you had to die and ruin everything, hadn't you?");
+                    .append(formatSeconds(System.currentTimeMillis() / 1000 - timerStart))
+                    .append("§r, but you had to die and ruin everything, hadn't you?");
         } else {
             sb.append("If ").append(beginning).append(" for §6")
-                .append(formatSeconds(secondsBeforeDecreased - System.currentTimeMillis() / 1000 + timerStart))
-                .append("§r, then the difficulty would’ve decreased... But you chose your fate.");
+                    .append(formatSeconds(secondsBeforeDecreased - System.currentTimeMillis() / 1000 + timerStart))
+                    .append("§r, then the difficulty would’ve decreased... But you chose your fate.");
         }
         sb.append("\n§8=============================================§r");
         return sb.toString();

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyManager.java
@@ -148,17 +148,6 @@ public abstract class DifficultyManager extends DifficultyTimer {
     public void updateTimerTask() {
         if (reducerTask != null) reducerTask.cancel();
         if (numberOfDeath == 0) return;
-        final var task = new TimerTask() {
-            @Override
-            public void run() {
-                timerStart = System.currentTimeMillis() / 1000;
-                decreaseDeath();
-                if (numberOfDeath == 0) {
-                    reducerTask.cancel();
-                    timerStart = -1;
-                }
-            }
-        };
         timerStart = System.currentTimeMillis() / 1000;
         reducerTask = executeTask(() -> {
             timerStart = System.currentTimeMillis() / 1000;

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyTimer.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyTimer.java
@@ -15,11 +15,11 @@ public abstract class DifficultyTimer {
         initialDelay = delay;
     }
 
-    protected TickTask executeTask(TickTask.Task task, @Nullable TickTask pastTask, long repeatEach) {
+    protected TickTask executeTask(TimerAccess.Task task, @Nullable TimerAccess.TickTask pastTask, long repeatEach) {
         return executeTask(task, pastTask, repeatEach, repeatEach);
     }
 
-    protected TickTask executeTask(TickTask.Task task, @Nullable TickTask pastTask, long delay, long repeatEach) {
+    protected TickTask executeTask(TimerAccess.Task task, @Nullable TimerAccess.TickTask pastTask, long delay, long repeatEach) {
         if (timer == null) throw new IllegalStateException("Timer has not been initialized");
         if (pastTask == null && initialDelay != 0) {
             TickTask tt;
@@ -62,10 +62,6 @@ public abstract class DifficultyTimer {
         sb.append(seconds).append(" seconds");
 
         return sb.toString();
-    }
-
-    public void stop() {
-        if (timer != null) timer.dds_cancel();
     }
 
     public long delay() {

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyTimer.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyTimer.java
@@ -2,39 +2,43 @@ package world.anhgelus.architectsland.difficultydeathscaler.difficulty;
 
 import org.jetbrains.annotations.Nullable;
 import world.anhgelus.architectsland.difficultydeathscaler.DifficultyDeathScaler;
-
-import java.util.Timer;
-import java.util.TimerTask;
+import world.anhgelus.architectsland.difficultydeathscaler.timer.TickTask;
+import world.anhgelus.architectsland.difficultydeathscaler.timer.TimerAccess;
 
 public abstract class DifficultyTimer {
     protected long initialDelay = 0;
     protected long timerStart = System.currentTimeMillis() / 1000;
 
-    protected Timer timer;
+    protected TimerAccess timer;
 
     protected void delayFirstTask(long delay) {
         initialDelay = delay;
     }
 
-    protected void executeTask(TimerTask task, @Nullable TimerTask pastTask, long repeatEach) {
-        executeTask(task, pastTask, repeatEach, repeatEach);
+    protected TickTask executeTask(TickTask.Task task, @Nullable TickTask pastTask, long repeatEach) {
+        return executeTask(task, pastTask, repeatEach, repeatEach);
     }
 
-    protected void executeTask(TimerTask task, @Nullable TimerTask pastTask, long delay, long repeatEach) {
+    protected TickTask executeTask(TickTask.Task task, @Nullable TickTask pastTask, long delay, long repeatEach) {
         if (timer == null) throw new IllegalStateException("Timer has not been initialized");
         if (pastTask == null && initialDelay != 0) {
+            TickTask tt;
             try {
-                timer.schedule(task, (delay - initialDelay) * 1000L, repeatEach * 1000L);
+                tt = new TickTask(task, (delay - initialDelay) * 20L, repeatEach * 20L);
+                timer.dds_runTask(tt);
                 timerStart -= initialDelay;
             } catch (IllegalArgumentException e) {
                 DifficultyDeathScaler.LOGGER.error("An exception occurred while launching the first task", e);
                 DifficultyDeathScaler.LOGGER.warn("Resetting delay to 0");
                 initialDelay = 0;
-                timer.schedule(task, delay * 1000L, repeatEach * 1000L);
+                tt = new TickTask(task, delay * 20L, repeatEach * 20L);
+                timer.dds_runTask(tt);
             }
-            return;
+            return tt;
         }
-        timer.schedule(task, delay * 1000L, repeatEach * 1000L);
+        final var tt = new TickTask(task, delay * 20L, repeatEach * 20L);
+        timer.dds_runTask(tt);
+        return tt;
     }
 
     protected static String formatSeconds(long time) {
@@ -61,7 +65,7 @@ public abstract class DifficultyTimer {
     }
 
     public void stop() {
-        if (timer != null) timer.cancel();
+        if (timer != null) timer.dds_cancel();
     }
 
     public long delay() {

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyTimer.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyTimer.java
@@ -68,7 +68,11 @@ public abstract class DifficultyTimer {
         return delay(timerStart);
     }
 
-    public long delay(long timerStart) {
+    public static long delay(long timerStart) {
         return System.currentTimeMillis() / 1000 - timerStart;
+    }
+
+    protected static String formatSecondsBeforeRun(TimerAccess.TickTask task) {
+        return formatSeconds(task.getTickingBeforeRun() / 20);
     }
 }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyTimer.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyTimer.java
@@ -6,8 +6,7 @@ import world.anhgelus.architectsland.difficultydeathscaler.timer.TickTask;
 import world.anhgelus.architectsland.difficultydeathscaler.timer.TimerAccess;
 
 public abstract class DifficultyTimer {
-    protected long initialDelay = 0;
-    protected long timerStart = System.currentTimeMillis() / 1000;
+    private long initialDelay = 0;
 
     protected TimerAccess timer;
 
@@ -26,7 +25,6 @@ public abstract class DifficultyTimer {
             try {
                 tt = new TickTask(task, delay * 20L - initialDelay, repeatEach * 20L);
                 timer.dds_runTask(tt);
-                timerStart -= initialDelay / 20;
             } catch (IllegalArgumentException e) {
                 DifficultyDeathScaler.LOGGER.error("An exception occurred while launching the first task", e);
                 DifficultyDeathScaler.LOGGER.warn("Resetting delay to 0");
@@ -62,10 +60,6 @@ public abstract class DifficultyTimer {
         sb.append(seconds).append(" seconds");
 
         return sb.toString();
-    }
-
-    public static long delay(long timerStart) {
-        return System.currentTimeMillis() / 1000 - timerStart;
     }
 
     protected static String formatSecondsBeforeRun(TimerAccess.TickTask task) {

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyTimer.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyTimer.java
@@ -24,9 +24,9 @@ public abstract class DifficultyTimer {
         if (pastTask == null && initialDelay != 0) {
             TickTask tt;
             try {
-                tt = new TickTask(task, (delay - initialDelay) * 20L, repeatEach * 20L);
+                tt = new TickTask(task, delay * 20L - initialDelay, repeatEach * 20L);
                 timer.dds_runTask(tt);
-                timerStart -= initialDelay;
+                timerStart -= initialDelay / 20;
             } catch (IllegalArgumentException e) {
                 DifficultyDeathScaler.LOGGER.error("An exception occurred while launching the first task", e);
                 DifficultyDeathScaler.LOGGER.warn("Resetting delay to 0");
@@ -62,10 +62,6 @@ public abstract class DifficultyTimer {
         sb.append(seconds).append(" seconds");
 
         return sb.toString();
-    }
-
-    public long delay() {
-        return delay(timerStart);
     }
 
     public static long delay(long timerStart) {

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyUpdater.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/DifficultyUpdater.java
@@ -1,0 +1,48 @@
+package world.anhgelus.architectsland.difficultydeathscaler.difficulty;
+
+import world.anhgelus.architectsland.difficultydeathscaler.difficulty.modifier.Modifier;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DifficultyUpdater {
+    private int difficultyLevel = 1;
+
+    private final Map<Class<? extends Modifier<?>>, Modifier<?>> map = new HashMap<>();
+
+    public void updateDifficulty(int level) {
+        if (level > difficultyLevel) {
+            difficultyLevel = level;
+        }
+    }
+
+    public Modifier<?> getModifier(Class<? extends Modifier<?>> clazz) {
+        var val = map.get(clazz);
+        if (val != null) return val;
+        try {
+            val = clazz.getConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
+                 NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+        map.put(clazz, val);
+        return val;
+    }
+
+    public List<Modifier<?>> getModifiers() {
+        return new ArrayList<>(map.values());
+    }
+
+    public net.minecraft.world.Difficulty getDifficulty() {
+        return switch (difficultyLevel) {
+            case 0 -> net.minecraft.world.Difficulty.PEACEFUL;
+            case 1 -> net.minecraft.world.Difficulty.EASY;
+            case 2 -> net.minecraft.world.Difficulty.NORMAL;
+            case 3 -> net.minecraft.world.Difficulty.HARD;
+            default -> throw new IllegalArgumentException("Difficulty level out of range: " + difficultyLevel);
+        };
+    }
+}

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/StateSaver.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/StateSaver.java
@@ -7,6 +7,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.world.PersistentState;
 import net.minecraft.world.World;
 import world.anhgelus.architectsland.difficultydeathscaler.DifficultyDeathScaler;
+import world.anhgelus.architectsland.difficultydeathscaler.difficulty.global.GlobalData;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.player.PlayerData;
 
 import java.util.HashMap;
@@ -15,13 +16,7 @@ import java.util.UUID;
 
 public class StateSaver extends PersistentState {
     public Map<UUID, PlayerData> players = new HashMap<>();
-
-    public int deaths = 0;
-    public long timeBeforeReduce = 0;
-    public long timeBeforeIncrease = 0;
-    public boolean increaseEnabled = false;
-    public int totalOfDeath = 0;
-    public long secondsLowerDifficulty = 0;
+    public GlobalData difficulty;
 
     @Override
     public NbtCompound writeNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup registryLookup) {
@@ -40,18 +35,19 @@ public class StateSaver extends PersistentState {
             playersNbt.put(uuid.toString(), playerNbt);
         });
         nbt.put("players", playersNbt);
-        nbt.putInt("deaths", deaths);
-        nbt.putLong("timeBeforeReduce", timeBeforeReduce);
-        nbt.putLong("timeBeforeIncrease", timeBeforeIncrease);
-        nbt.putBoolean("increaseEnabled", increaseEnabled);
-        nbt.putInt("totalOfDeath", totalOfDeath);
-        nbt.putLong("secondsLowerDifficulty", secondsLowerDifficulty);
+        nbt.putInt("deaths", difficulty.deaths);
+        nbt.putLong("timeBeforeReduce", difficulty.timeBeforeReduce);
+        nbt.putLong("timeBeforeIncrease", difficulty.timeBeforeIncrease);
+        nbt.putBoolean("increaseEnabled", difficulty.increaseEnabled);
+        nbt.putInt("totalOfDeath", difficulty.totalOfDeath);
+        nbt.putLong("secondsLowerDifficulty", difficulty.secondsLowerDifficulty);
 
         return nbt;
     }
 
     public static StateSaver createFromNbt(NbtCompound tag, RegistryWrapper.WrapperLookup registryLookup) {
         final var state = new StateSaver();
+        state.difficulty = new GlobalData();
 
         final var playersNbt = tag.getCompound("players");
         playersNbt.getKeys().forEach(key -> {
@@ -69,12 +65,12 @@ public class StateSaver extends PersistentState {
 
             state.players.put(UUID.fromString(key), playerData);
         });
-        state.deaths = tag.getInt("deaths");
-        state.timeBeforeReduce = tag.getLong("timeBeforeReduce");
-        state.timeBeforeIncrease = tag.getLong("timeBeforeIncrease");
-        state.increaseEnabled = tag.getBoolean("increaseEnabled");
-        state.totalOfDeath = tag.getInt("totalOfDeath");
-        state.secondsLowerDifficulty = tag.getInt("secondsLowerDifficulty");
+        state.difficulty.deaths = tag.getInt("deaths");
+        state.difficulty.timeBeforeReduce = tag.getLong("timeBeforeReduce");
+        state.difficulty.timeBeforeIncrease = tag.getLong("timeBeforeIncrease");
+        state.difficulty.increaseEnabled = tag.getBoolean("increaseEnabled");
+        state.difficulty.totalOfDeath = tag.getInt("totalOfDeath");
+        state.difficulty.secondsLowerDifficulty = tag.getInt("secondsLowerDifficulty");
 
         return state;
     }
@@ -93,6 +89,8 @@ public class StateSaver extends PersistentState {
         final var state = persistentStateManager.getOrCreate(type, DifficultyDeathScaler.MOD_ID);
 
         state.markDirty();
+
+        if (state.difficulty == null) state.difficulty = new GlobalData();
 
         return state;
     }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/StateSaver.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/StateSaver.java
@@ -9,7 +9,9 @@ import net.minecraft.world.World;
 import world.anhgelus.architectsland.difficultydeathscaler.DifficultyDeathScaler;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.player.PlayerData;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 public class StateSaver extends PersistentState {
     public Map<UUID, PlayerData> players = new HashMap<>();
@@ -19,6 +21,7 @@ public class StateSaver extends PersistentState {
     public long timeBeforeIncrease = 0;
     public boolean increaseEnabled = false;
     public int totalOfDeath = 0;
+    public long secondsLowerDifficulty = 0;
 
     @Override
     public NbtCompound writeNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup registryLookup) {
@@ -32,6 +35,7 @@ public class StateSaver extends PersistentState {
             playerNbt.putLongArray("deathDayDelay", playerData.deathDayDelay);
             playerNbt.putInt("totalOfDeath", playerData.totalOfDeath);
             playerNbt.putLong("bannedSince", playerData.bannedSince);
+            playerNbt.putLong("secondsLowerDifficulty", playerData.secondsLowerDifficulty);
 
             playersNbt.put(uuid.toString(), playerNbt);
         });
@@ -41,6 +45,7 @@ public class StateSaver extends PersistentState {
         nbt.putLong("timeBeforeIncrease", timeBeforeIncrease);
         nbt.putBoolean("increaseEnabled", increaseEnabled);
         nbt.putInt("totalOfDeath", totalOfDeath);
+        nbt.putLong("secondsLowerDifficulty", secondsLowerDifficulty);
 
         return nbt;
     }
@@ -59,6 +64,8 @@ public class StateSaver extends PersistentState {
             playerData.deathDayDelay = compound.getLongArray("deathDayDelay");
             playerData.totalOfDeath = compound.getInt("totalOfDeath");
             if (compound.contains("bannedSince")) playerData.bannedSince = compound.getLong("bannedSince");
+            if (compound.contains("secondsLowerDifficulty"))
+                playerData.secondsLowerDifficulty = compound.getLong("secondsLowerDifficulty");
 
             state.players.put(UUID.fromString(key), playerData);
         });
@@ -67,6 +74,7 @@ public class StateSaver extends PersistentState {
         state.timeBeforeIncrease = tag.getLong("timeBeforeIncrease");
         state.increaseEnabled = tag.getBoolean("increaseEnabled");
         state.totalOfDeath = tag.getInt("totalOfDeath");
+        state.secondsLowerDifficulty = tag.getInt("secondsLowerDifficulty");
 
         return state;
     }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/DifficultyIncrease.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/DifficultyIncrease.java
@@ -22,7 +22,7 @@ public class DifficultyIncrease extends DifficultyTimer {
     }
 
     public void restart() {
-        if (increaseTask != null) increaseTask.cancel();
+        if (increaseTask != null && !increaseTask.isCancelled()) increaseTask.cancel();
         final TimerAccess.Task task = () -> {
             enabled = true;
             manager.increaseDeath(true);

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/DifficultyIncrease.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/DifficultyIncrease.java
@@ -22,7 +22,7 @@ public class DifficultyIncrease extends DifficultyTimer {
     }
 
     public void restart() {
-        if (increaseTask != null && !increaseTask.isCancelled()) increaseTask.cancel();
+        if (increaseTask != null && increaseTask.isRunning()) increaseTask.cancel();
         final TimerAccess.Task task = () -> {
             enabled = true;
             manager.increaseDeath(true);
@@ -36,5 +36,9 @@ public class DifficultyIncrease extends DifficultyTimer {
 
     public boolean isEnabled() {
         return enabled;
+    }
+
+    public long getTickingBeforeRun() {
+        return increaseTask.getTickingBeforeRun();
     }
 }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/DifficultyIncrease.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/DifficultyIncrease.java
@@ -31,7 +31,6 @@ public class DifficultyIncrease extends DifficultyTimer {
         if (enabled) increaseTask = executeTask(task, increaseTask, SECONDS_EACH_INCREASE);
         else increaseTask = executeTask(task, increaseTask, SECONDS_BEFORE_INCREASE, SECONDS_EACH_INCREASE);
         enabled = false;
-        timerStart = System.currentTimeMillis() / 1000;
     }
 
     public boolean isEnabled() {

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/DifficultyIncrease.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/DifficultyIncrease.java
@@ -23,7 +23,7 @@ public class DifficultyIncrease extends DifficultyTimer {
 
     public void restart() {
         if (increaseTask != null) increaseTask.cancel();
-        final TickTask.Task task = () -> {
+        final TimerAccess.Task task = () -> {
             enabled = true;
             manager.increaseDeath(true);
             manager.stopAutomaticDecrease();

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/DifficultyIncrease.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/DifficultyIncrease.java
@@ -1,20 +1,19 @@
 package world.anhgelus.architectsland.difficultydeathscaler.difficulty.global;
 
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.DifficultyTimer;
-
-import java.util.Timer;
-import java.util.TimerTask;
+import world.anhgelus.architectsland.difficultydeathscaler.timer.TickTask;
+import world.anhgelus.architectsland.difficultydeathscaler.timer.TimerAccess;
 
 public class DifficultyIncrease extends DifficultyTimer {
-    public static final int SECONDS_BEFORE_INCREASE = 3*24*60*60; // 3 days
-    public static final int SECONDS_EACH_INCREASE = 12*60*60; // 12 hours
+    public static final int SECONDS_BEFORE_INCREASE = 3 * 24 * 60 * 60; // 3 days
+    public static final int SECONDS_EACH_INCREASE = 12 * 60 * 60; // 12 hours
 
     private final GlobalDifficultyManager manager;
 
-    private TimerTask increaseTask;
+    private TickTask increaseTask;
     private boolean enabled;
 
-    public DifficultyIncrease(GlobalDifficultyManager manager, Timer timer, long initialDelay, boolean enabled) {
+    public DifficultyIncrease(GlobalDifficultyManager manager, TimerAccess timer, long initialDelay, boolean enabled) {
         this.manager = manager;
         this.enabled = enabled;
         this.timer = timer;
@@ -24,18 +23,14 @@ public class DifficultyIncrease extends DifficultyTimer {
 
     public void restart() {
         if (increaseTask != null) increaseTask.cancel();
-        final var task = new TimerTask() {
-            @Override
-            public void run() {
-                enabled = true;
-                manager.increaseDeath(true);
-                manager.stopAutomaticDecrease();
-            }
+        final TickTask.Task task = () -> {
+            enabled = true;
+            manager.increaseDeath(true);
+            manager.stopAutomaticDecrease();
         };
-        if (enabled) executeTask(task, increaseTask, SECONDS_EACH_INCREASE);
-        else executeTask(task, increaseTask, SECONDS_BEFORE_INCREASE, SECONDS_EACH_INCREASE);
+        if (enabled) increaseTask = executeTask(task, increaseTask, SECONDS_EACH_INCREASE);
+        else increaseTask = executeTask(task, increaseTask, SECONDS_BEFORE_INCREASE, SECONDS_EACH_INCREASE);
         enabled = false;
-        increaseTask = task;
         timerStart = System.currentTimeMillis() / 1000;
     }
 

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/GlobalData.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/GlobalData.java
@@ -1,0 +1,8 @@
+package world.anhgelus.architectsland.difficultydeathscaler.difficulty.global;
+
+import world.anhgelus.architectsland.difficultydeathscaler.difficulty.DifficultyData;
+
+public class GlobalData extends DifficultyData {
+    public long timeBeforeIncrease = 0;
+    public boolean increaseEnabled = false;
+}

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/GlobalDifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/GlobalDifficultyManager.java
@@ -162,11 +162,10 @@ public class GlobalDifficultyManager extends DifficultyManager {
 
         DifficultyDeathScaler.LOGGER.info("Loading global difficulty data");
         final var state = StateSaver.getServerState(server);
+        totalOfDeath = state.totalOfDeath;
         delayFirstTask(state.timeBeforeReduce);
         increaser = new DifficultyIncrease(this, timer, state.timeBeforeIncrease, state.increaseEnabled);
         setNumberOfDeath(state.deaths, true);
-        totalOfDeath = state.totalOfDeath;
-
         // update difficulty after restart
         server.setDifficulty(getUpdater().getDifficulty(), true);
 
@@ -278,10 +277,12 @@ public class GlobalDifficultyManager extends DifficultyManager {
         DifficultyDeathScaler.LOGGER.info("Saving global difficulty data");
         final var state = StateSaver.getServerState(server);
         state.deaths = numberOfDeath;
-        state.timeBeforeReduce = delay();
-        state.timeBeforeIncrease = increaser.delay();
-        state.increaseEnabled = increaser.isEnabled();
+        if (reducerTask != null && reducerTask.isRunning())
+            state.timeBeforeReduce = reducerTask.getTickingBeforeRun();
+        else state.timeBeforeReduce = 0;
         state.totalOfDeath = totalOfDeath;
+        state.timeBeforeIncrease = increaser.getTickingBeforeRun();
+        state.increaseEnabled = increaser.isEnabled();
     }
 
     public int getTotalOfDeath() {

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/GlobalDifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/GlobalDifficultyManager.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import world.anhgelus.architectsland.difficultydeathscaler.DifficultyDeathScaler;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.DifficultyManager;
+import world.anhgelus.architectsland.difficultydeathscaler.difficulty.DifficultyUpdater;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.StateSaver;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.modifier.*;
 import world.anhgelus.architectsland.difficultydeathscaler.utils.MobUtils;
@@ -171,7 +172,7 @@ public class GlobalDifficultyManager extends DifficultyManager {
     }
 
     @Override
-    protected void onUpdate(UpdateType updateType, Updater updater) {
+    protected void onUpdate(UpdateType updateType, DifficultyUpdater updater) {
         final var difficulty = updater.getDifficulty();
         server.setDifficulty(difficulty, true);
 

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/GlobalDifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/GlobalDifficultyManager.java
@@ -163,6 +163,7 @@ public class GlobalDifficultyManager extends DifficultyManager {
         DifficultyDeathScaler.LOGGER.info("Loading global difficulty data");
         final var state = StateSaver.getServerState(server);
         totalOfDeath = state.totalOfDeath;
+        secondsLowerDifficulty = state.secondsLowerDifficulty;
         delayFirstTask(state.timeBeforeReduce);
         increaser = new DifficultyIncrease(this, timer, state.timeBeforeIncrease, state.increaseEnabled);
         setNumberOfDeath(state.deaths, true);
@@ -283,6 +284,7 @@ public class GlobalDifficultyManager extends DifficultyManager {
         state.totalOfDeath = totalOfDeath;
         state.timeBeforeIncrease = increaser.getTickingBeforeRun();
         state.increaseEnabled = increaser.isEnabled();
+        state.secondsLowerDifficulty = secondsLowerDifficulty;
     }
 
     public int getTotalOfDeath() {

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/GlobalDifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/GlobalDifficultyManager.java
@@ -22,9 +22,9 @@ import world.anhgelus.architectsland.difficultydeathscaler.utils.MobUtils;
 import java.util.List;
 
 public class GlobalDifficultyManager extends DifficultyManager {
-    public static final int SECONDS_BEFORE_DECREASED = 12 * 60 * 60; // 12 hours
+    public static final int SECONDS_BEFORE_DECREASED = 12; // 12 hours
 
-    private final DifficultyIncrease increaser; // 12 hours
+    private final DifficultyIncrease increaser;
 
     public static class HealthModifier extends PlayerHealthModifier {
         public static final Identifier ID = Identifier.of(PREFIX + "global_health_modifier");

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/GlobalDifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/global/GlobalDifficultyManager.java
@@ -160,17 +160,14 @@ public class GlobalDifficultyManager extends DifficultyManager {
     public GlobalDifficultyManager(MinecraftServer server) {
         super(server, STEPS, SECONDS_BEFORE_DECREASED);
 
+        // get state
         DifficultyDeathScaler.LOGGER.info("Loading global difficulty data");
         final var state = StateSaver.getServerState(server);
-        totalOfDeath = state.totalOfDeath;
-        secondsLowerDifficulty = state.secondsLowerDifficulty;
-        delayFirstTask(state.timeBeforeReduce);
-        increaser = new DifficultyIncrease(this, timer, state.timeBeforeIncrease, state.increaseEnabled);
-        setNumberOfDeath(state.deaths, true);
+        // load data
+        increaser = new DifficultyIncrease(this, timer, state.difficulty.timeBeforeIncrease, state.difficulty.increaseEnabled);
+        load(state.difficulty);
         // update difficulty after restart
         server.setDifficulty(getUpdater().getDifficulty(), true);
-
-        updateModifiersValue(getModifiers(numberOfDeath));
     }
 
     @Override
@@ -273,18 +270,15 @@ public class GlobalDifficultyManager extends DifficultyManager {
             });
     }
 
-    @Override
     public void save() {
+        // get state
         DifficultyDeathScaler.LOGGER.info("Saving global difficulty data");
         final var state = StateSaver.getServerState(server);
-        state.deaths = numberOfDeath;
-        if (reducerTask != null && reducerTask.isRunning())
-            state.timeBeforeReduce = reducerTask.getTickingBeforeRun();
-        else state.timeBeforeReduce = 0;
-        state.totalOfDeath = totalOfDeath;
-        state.timeBeforeIncrease = increaser.getTickingBeforeRun();
-        state.increaseEnabled = increaser.isEnabled();
-        state.secondsLowerDifficulty = secondsLowerDifficulty;
+        // save state
+        save(state.difficulty);
+
+        state.difficulty.timeBeforeIncrease = increaser.getTickingBeforeRun();
+        state.difficulty.increaseEnabled = increaser.isEnabled();
     }
 
     public int getTotalOfDeath() {

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/Bounty.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/Bounty.java
@@ -67,7 +67,7 @@ public class Bounty extends DifficultyTimer {
 
     public void onKill(PlayerDifficultyManager attackerDifficulty) {
         if (!enabled) return;
-        disable();
+        enabled = false;
         assert attackerDifficulty.player != null;
         final var sb = new StringBuilder();
         sb.append("§8==================== §rBounty! §8====================§r\n");
@@ -99,12 +99,12 @@ public class Bounty extends DifficultyTimer {
         if (!enabled) return;
         player = playerDifficulty.player;
         if ((double) playerDifficulty.getTotalOfDeath() / globalDifficulty.getTotalOfDeath() > BOUNTY_DEATH_PERCENTAGE)
-            disable();
+            enabled = false;
     }
 
     public void onDisconnect() {
         if (!enabled) return;
-        disable();
+        enabled = false;
         final var sb = new StringBuilder();
         sb.append("§8==================== §rBounty! §8====================§r\n");
 
@@ -117,17 +117,6 @@ public class Bounty extends DifficultyTimer {
 
         if (player.getServer() == null) return;
         player.getServer().getPlayerManager().broadcast(Text.of(sb.toString()), false);
-    }
-
-    private void disable() {
-        enabled = false;
-        stop();
-    }
-
-    @Override
-    public void stop() {
-        if (!enabled) return;
-        disable();
     }
 
     @Nullable

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/Bounty.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/Bounty.java
@@ -1,15 +1,15 @@
 package world.anhgelus.architectsland.difficultydeathscaler.difficulty.player;
 
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import org.jetbrains.annotations.Nullable;
 import world.anhgelus.architectsland.difficultydeathscaler.DifficultyDeathScaler;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.DifficultyTimer;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.global.GlobalDifficultyManager;
+import world.anhgelus.architectsland.difficultydeathscaler.timer.TickTask;
+import world.anhgelus.architectsland.difficultydeathscaler.timer.TimerAccess;
 import world.anhgelus.architectsland.difficultydeathscaler.utils.Getters;
-
-import java.util.Timer;
-import java.util.TimerTask;
 
 public class Bounty extends DifficultyTimer {
     public static final double BOUNTY_DEATH_PERCENTAGE = 0.04;
@@ -21,8 +21,8 @@ public class Bounty extends DifficultyTimer {
 
     private boolean enabled = false;
 
-    private Bounty(GlobalDifficultyManager globalDifficulty, PlayerDifficultyManager playerDifficulty) {
-        timer = new Timer();
+    private Bounty(MinecraftServer server, GlobalDifficultyManager globalDifficulty, PlayerDifficultyManager playerDifficulty) {
+        timer = TimerAccess.getTimerFromOverworld(server);
         this.globalDifficulty = globalDifficulty;
         this.playerDifficulty = playerDifficulty;
         this.player = playerDifficulty.player;
@@ -31,13 +31,10 @@ public class Bounty extends DifficultyTimer {
 
         DifficultyDeathScaler.LOGGER.info("New bounty {} broadcast in {} minutes", this, delay * 5);
 
-        timer.schedule(new TimerTask() {
-            @Override
-            public void run() {
-                enabled = true;
-                bountyBroadcast();
-            }
-        }, Math.round(delay * 5 * 60 * 1000L));
+        timer.dds_runTask(new TickTask(() -> {
+            enabled = true;
+            bountyBroadcast();
+        }, Math.round(delay * 5 * 60 * 20L)));
     }
 
     private void bountyBroadcast() {
@@ -134,11 +131,11 @@ public class Bounty extends DifficultyTimer {
     }
 
     @Nullable
-    public static Bounty newBounty(GlobalDifficultyManager globalDifficulty, PlayerDifficultyManager playerDifficulty) {
+    public static Bounty newBounty(MinecraftServer server, GlobalDifficultyManager globalDifficulty, PlayerDifficultyManager playerDifficulty) {
         if (globalDifficulty.getTotalOfDeath() >= BOUNTY_ENABLED_AFTER &&
                 (double) playerDifficulty.getTotalOfDeath() / globalDifficulty.getTotalOfDeath() <= BOUNTY_DEATH_PERCENTAGE
         ) {
-            return new Bounty(globalDifficulty, playerDifficulty);
+            return new Bounty(server, globalDifficulty, playerDifficulty);
         }
         return null;
     }
@@ -153,7 +150,7 @@ public class Bounty extends DifficultyTimer {
                 .append(", player_uuid=").append(player.getUuid())
                 .append(", player_totalDeath=").append(playerDifficulty.getTotalOfDeath())
                 .append(", global_totalDeath=").append(globalDifficulty.getTotalOfDeath())
-                .append(", player_deathPercentage=").append((float) playerDifficulty.getTotalOfDeath()/globalDifficulty.getTotalOfDeath())
+                .append(", player_deathPercentage=").append((float) playerDifficulty.getTotalOfDeath() / globalDifficulty.getTotalOfDeath())
                 .append(")");
         return sb.toString();
     }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerData.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerData.java
@@ -7,4 +7,5 @@ public class PlayerData {
     public int totalOfDeath = 0;
     public long[] deathDayDelay = new long[]{};
     public long bannedSince = -1;
+    public long secondsLowerDifficulty = 0;
 }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerData.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerData.java
@@ -1,11 +1,9 @@
 package world.anhgelus.architectsland.difficultydeathscaler.difficulty.player;
 
-public class PlayerData {
-    public int deaths = 0;
-    public long timeBeforeReduce = 0;
+import world.anhgelus.architectsland.difficultydeathscaler.difficulty.DifficultyData;
+
+public class PlayerData extends DifficultyData {
     public int deathDay = 0;
-    public int totalOfDeath = 0;
     public long[] deathDayDelay = new long[]{};
     public long bannedSince = -1;
-    public long secondsLowerDifficulty = 0;
 }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerDifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerDifficultyManager.java
@@ -28,7 +28,7 @@ public class PlayerDifficultyManager extends DifficultyManager {
     public @Nullable ServerPlayerEntity player;
     public @Nullable UUID uuid = null;
 
-    public static final int SECONDS_BEFORE_DECREASED = 24 * 60 * 60;
+    public static final int SECONDS_BEFORE_DECREASED = 24;
 
     public static class HealthModifier extends PlayerHealthModifier {
         public static final Identifier ID = Identifier.of(PREFIX + "player_health_modifier");
@@ -140,12 +140,12 @@ public class PlayerDifficultyManager extends DifficultyManager {
 
     @Override
     protected void onUpdate(UpdateType updateType, Updater updater) {
+        updateModifiersValue(updater);
+
         if (player == null) {
             DifficultyDeathScaler.LOGGER.warn("Player in {} is null", this);
             return;
         }
-
-        updateModifiersValue(updater);
 
         player.sendMessage(Text.of(generateDifficultyUpdate(updateType, updater.getDifficulty())), false);
 
@@ -158,7 +158,7 @@ public class PlayerDifficultyManager extends DifficultyManager {
         deathDay++;
 
         if (player == null) {
-            DifficultyDeathScaler.LOGGER.warn("Updating death of null player. UpdateType {}", updateType);
+            DifficultyDeathScaler.LOGGER.error("Updating death of null player. UpdateType {}", updateType);
             throw new IllegalStateException("Player is null");
         }
         if (player.getWorld().isClient()) return;
@@ -178,16 +178,16 @@ public class PlayerDifficultyManager extends DifficultyManager {
         modifiers.forEach(m -> {
             if (m instanceof final HealthModifier mod) {
                 healthModifier = mod.getValue();
-                mod.apply(player);
+                if (player != null) mod.apply(player);
             }/* else if (m instanceof final LuckModifier mod) {
                 luckModifier = mod.getValue();
                 mod.apply(player);
             } */ else if (m instanceof final BlockBreakSpeedModifier mod) {
                 blockBreakSpeedModifier = mod.getValue();
-                mod.apply(player);
+                if (player != null) mod.apply(player);
             } else if (m instanceof final MovementSpeedModifier mod) {
                 movementSpeedModifier = mod.getValue();
-                mod.apply(player);
+                if (player != null) mod.apply(player);
             }
         });
     }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerDifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerDifficultyManager.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import world.anhgelus.architectsland.difficultydeathscaler.DifficultyDeathScaler;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.DifficultyManager;
+import world.anhgelus.architectsland.difficultydeathscaler.difficulty.DifficultyUpdater;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.StateSaver;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.global.GlobalDifficultyManager;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.modifier.BlockBreakSpeedModifier;
@@ -99,7 +100,7 @@ public class PlayerDifficultyManager extends DifficultyManager {
         this.player = player;
         this.globalManager = globalManager;
 
-        DifficultyDeathScaler.LOGGER.info("Loading player {} difficulty data", player.getUuid());
+        DifficultyDeathScaler.LOGGER.info("Loading player ({}) difficulty data", player.getUuid());
         load(StateSaver.getPlayerState(player));
     }
 
@@ -109,7 +110,7 @@ public class PlayerDifficultyManager extends DifficultyManager {
         this.uuid = uuid;
         this.globalManager = globalManager;
 
-        DifficultyDeathScaler.LOGGER.info("Creating player difficulty manager with data");
+        DifficultyDeathScaler.LOGGER.info("Creating player ({}) difficulty manager with data", uuid);
         load(data);
     }
 
@@ -131,8 +132,10 @@ public class PlayerDifficultyManager extends DifficultyManager {
 
 
     @Override
-    protected void onUpdate(UpdateType updateType, Updater updater) {
+    protected void onUpdate(UpdateType updateType, DifficultyUpdater updater) {
         updateModifiersValue(updater);
+
+        if (updateType == UpdateType.SILENT) return;
 
         if (player == null) {
             DifficultyDeathScaler.LOGGER.warn("Player in {} is null", this);
@@ -145,7 +148,7 @@ public class PlayerDifficultyManager extends DifficultyManager {
     }
 
     @Override
-    protected void onDeath(UpdateType updateType, Updater updater) {
+    protected void onDeath(UpdateType updateType, DifficultyUpdater updater) {
         if (updateType == UpdateType.SET || updateType == UpdateType.SILENT) return;
         deathDay++;
 

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerDifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerDifficultyManager.java
@@ -94,15 +94,13 @@ public class PlayerDifficultyManager extends DifficultyManager {
     private long bannedSince = -1;
     private final List<TickTask> deathDayTasks = new ArrayList<>();
 
-    private int totalOfDeath = 0;
-
     public PlayerDifficultyManager(MinecraftServer server, GlobalDifficultyManager globalManager, ServerPlayerEntity player) {
         super(server, STEPS, SECONDS_BEFORE_DECREASED);
         this.player = player;
         this.globalManager = globalManager;
 
         DifficultyDeathScaler.LOGGER.info("Loading player {} difficulty data", player.getUuid());
-        loadData(StateSaver.getPlayerState(player));
+        load(StateSaver.getPlayerState(player));
     }
 
     public PlayerDifficultyManager(MinecraftServer server, GlobalDifficultyManager globalManager, @NotNull UUID uuid, PlayerData data) {
@@ -112,16 +110,14 @@ public class PlayerDifficultyManager extends DifficultyManager {
         this.globalManager = globalManager;
 
         DifficultyDeathScaler.LOGGER.info("Creating player difficulty manager with data");
-        loadData(data);
+        load(data);
     }
 
-    private void loadData(PlayerData data) {
-        numberOfDeath = data.deaths;
+    private void load(PlayerData data) {
+        super.load(data);
         deathDay = data.deathDay;
-        totalOfDeath = data.totalOfDeath;
         bannedSince = data.bannedSince;
         tempBan = bannedSince != -1;
-        secondsLowerDifficulty = data.secondsLowerDifficulty;
         for (final var ticksDelay : data.deathDayDelay) {
             try {
                 scheduleDeathDayTask(ticksDelay);
@@ -131,9 +127,6 @@ public class PlayerDifficultyManager extends DifficultyManager {
                 deathDay--;
             }
         }
-        delayFirstTask(data.timeBeforeReduce);
-        updateTimerTask();
-        updateModifiersValue(getModifiers(numberOfDeath));
     }
 
 
@@ -153,7 +146,7 @@ public class PlayerDifficultyManager extends DifficultyManager {
 
     @Override
     protected void onDeath(UpdateType updateType, Updater updater) {
-        if (updateType == UpdateType.SET) return;
+        if (updateType == UpdateType.SET || updateType == UpdateType.SILENT) return;
         deathDay++;
 
         if (player == null) {
@@ -235,9 +228,9 @@ public class PlayerDifficultyManager extends DifficultyManager {
         applyModifiers();
     }
 
-    @Override
     public void save() {
         assert player != null || uuid != null;
+        // get state
         PlayerData state;
         if (player == null) {
             DifficultyDeathScaler.LOGGER.info("Saving player with uuid {} difficulty data", uuid);
@@ -246,20 +239,18 @@ public class PlayerDifficultyManager extends DifficultyManager {
             DifficultyDeathScaler.LOGGER.info("Saving player ({}) difficulty data", player.getUuid());
             state = StateSaver.getPlayerState(player);
         }
-        state.deaths = numberOfDeath;
-        if (reducerTask != null && reducerTask.isRunning())
-            state.timeBeforeReduce = reducerTask.getTickingBeforeRun();
-        else state.timeBeforeReduce = 0;
+        // save state
+        save(state);
+
         state.deathDay = deathDay;
-        state.totalOfDeath = totalOfDeath;
         state.bannedSince = bannedSince;
+
         final var runningDeathDay = deathDayTasks.stream().filter(TickTask::isRunning).toList();
         var starts = new long[runningDeathDay.size()];
         for (int i = 0; i < runningDeathDay.size(); i++) {
             starts[i] = runningDeathDay.get(i).getTickingBeforeRun();
         }
         state.deathDayDelay = starts;
-        state.secondsLowerDifficulty = secondsLowerDifficulty;
     }
 
     public void applyModifiers() {
@@ -287,7 +278,7 @@ public class PlayerDifficultyManager extends DifficultyManager {
     }
 
     private void scheduleDeathDayTask() {
-        scheduleDeathDayTask(0);
+        scheduleDeathDayTask((24 * 60 * 60) * 20L);
     }
 
     private void scheduleDeathDayTask(long ticksDelay) {
@@ -296,7 +287,7 @@ public class PlayerDifficultyManager extends DifficultyManager {
                 deathDay--;
                 deathDayTasks.removeFirst();
             } else DifficultyDeathScaler.LOGGER.warn("Death day is already equal to 0");
-        }, (24 * 60 * 60) * 20L - ticksDelay);
+        }, ticksDelay);
         timer.dds_runTask(task);
         deathDayTasks.add(task);
     }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerDifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerDifficultyManager.java
@@ -18,10 +18,10 @@ import world.anhgelus.architectsland.difficultydeathscaler.difficulty.modifier.B
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.modifier.Modifier;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.modifier.MovementSpeedModifier;
 import world.anhgelus.architectsland.difficultydeathscaler.difficulty.modifier.PlayerHealthModifier;
+import world.anhgelus.architectsland.difficultydeathscaler.timer.TickTask;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.TimerTask;
 import java.util.UUID;
 
 public class PlayerDifficultyManager extends DifficultyManager {
@@ -93,7 +93,7 @@ public class PlayerDifficultyManager extends DifficultyManager {
     private boolean tempBan;
     private long bannedSince = -1;
     private final List<Long> deathDayStart = new ArrayList<>();
-    private final List<TimerTask> deathDayTasks = new ArrayList<>();
+    private final List<TickTask> deathDayTasks = new ArrayList<>();
 
     private int totalOfDeath = 0;
 
@@ -293,23 +293,20 @@ public class PlayerDifficultyManager extends DifficultyManager {
         } else {
             deathDayStart.add(delayTime);
         }
-        final var task = new TimerTask() {
-            @Override
-            public void run() {
-                if (deathDay != 0) {
-                    deathDay--;
-                    deathDayStart.removeFirst();
-                } else DifficultyDeathScaler.LOGGER.warn("Death day is already equal to 0");
-            }
-        };
-        timer.schedule(task, (24 * 60 * 60 - delayTime) * 1000L);
+        final var task = new TickTask(() -> {
+            if (deathDay != 0) {
+                deathDay--;
+                deathDayStart.removeFirst();
+            } else DifficultyDeathScaler.LOGGER.warn("Death day is already equal to 0");
+        }, (24 * 60 * 60 - delayTime) * 20L);
+        timer.dds_runTask(task);
         deathDayTasks.add(task);
     }
 
     private void resetDeathDay() {
         deathDay = 0;
         deathDayStart.clear();
-        deathDayTasks.forEach(TimerTask::cancel);
+        deathDayTasks.forEach(TickTask::cancel);
         deathDayTasks.clear();
     }
 

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerDifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerDifficultyManager.java
@@ -92,7 +92,6 @@ public class PlayerDifficultyManager extends DifficultyManager {
     private int deathDay;
     private boolean tempBan;
     private long bannedSince = -1;
-    private final List<Long> deathDayStart = new ArrayList<>();
     private final List<TickTask> deathDayTasks = new ArrayList<>();
 
     private int totalOfDeath = 0;
@@ -122,10 +121,9 @@ public class PlayerDifficultyManager extends DifficultyManager {
         totalOfDeath = data.totalOfDeath;
         bannedSince = data.bannedSince;
         tempBan = bannedSince != -1;
-        for (final var delay : data.deathDayDelay) {
+        for (final var ticksDelay : data.deathDayDelay) {
             try {
-                scheduleDeathDayTask(delay);
-                deathDayStart.add(delay);
+                scheduleDeathDayTask(ticksDelay);
             } catch (IllegalArgumentException e) {
                 DifficultyDeathScaler.LOGGER.error("An error occurred while loading data", e);
                 DifficultyDeathScaler.LOGGER.warn("Removing one day death");
@@ -248,13 +246,16 @@ public class PlayerDifficultyManager extends DifficultyManager {
             state = StateSaver.getPlayerState(player);
         }
         state.deaths = numberOfDeath;
-        state.timeBeforeReduce = delay();
+        if (reducerTask != null && reducerTask.isRunning())
+            state.timeBeforeReduce = reducerTask.getTickingBeforeRun();
+        else state.timeBeforeReduce = 0;
         state.deathDay = deathDay;
         state.totalOfDeath = totalOfDeath;
         state.bannedSince = bannedSince;
-        var starts = new long[deathDayStart.size()];
-        for (int i = 0; i < deathDayStart.size(); i++) {
-            starts[i] = deathDayStart.get(i);
+        final var runningDeathDay = deathDayTasks.stream().filter(TickTask::isRunning).toList();
+        var starts = new long[runningDeathDay.size()];
+        for (int i = 0; i < runningDeathDay.size(); i++) {
+            starts[i] = runningDeathDay.get(i).getTickingBeforeRun();
         }
         state.deathDayDelay = starts;
     }
@@ -287,25 +288,19 @@ public class PlayerDifficultyManager extends DifficultyManager {
         scheduleDeathDayTask(0);
     }
 
-    private void scheduleDeathDayTask(long delayTime) {
-        if (delayTime == 0) {
-            deathDayStart.add(delay(System.currentTimeMillis() / 1000));
-        } else {
-            deathDayStart.add(delayTime);
-        }
+    private void scheduleDeathDayTask(long ticksDelay) {
         final var task = new TickTask(() -> {
             if (deathDay != 0) {
                 deathDay--;
-                deathDayStart.removeFirst();
+                deathDayTasks.removeFirst();
             } else DifficultyDeathScaler.LOGGER.warn("Death day is already equal to 0");
-        }, (24 * 60 * 60 - delayTime) * 20L);
+        }, (24 * 60 * 60) * 20L - ticksDelay);
         timer.dds_runTask(task);
         deathDayTasks.add(task);
     }
 
     private void resetDeathDay() {
         deathDay = 0;
-        deathDayStart.clear();
         deathDayTasks.forEach(TickTask::cancel);
         deathDayTasks.clear();
     }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerDifficultyManager.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/difficulty/player/PlayerDifficultyManager.java
@@ -121,6 +121,7 @@ public class PlayerDifficultyManager extends DifficultyManager {
         totalOfDeath = data.totalOfDeath;
         bannedSince = data.bannedSince;
         tempBan = bannedSince != -1;
+        secondsLowerDifficulty = data.secondsLowerDifficulty;
         for (final var ticksDelay : data.deathDayDelay) {
             try {
                 scheduleDeathDayTask(ticksDelay);
@@ -258,6 +259,7 @@ public class PlayerDifficultyManager extends DifficultyManager {
             starts[i] = runningDeathDay.get(i).getTickingBeforeRun();
         }
         state.deathDayDelay = starts;
+        state.secondsLowerDifficulty = secondsLowerDifficulty;
     }
 
     public void applyModifiers() {

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/mixin/WorldTimerAccess.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/mixin/WorldTimerAccess.java
@@ -19,7 +19,7 @@ public class WorldTimerAccess implements TimerAccess {
 
     @Inject(method = "tick", at = @At("TAIL"))
     private void onTick(BooleanSupplier shouldKeepTicking, CallbackInfo ci) {
-        tasks.stream().filter(t -> !t.isCancelled()).forEach(TickTask::tick);
+        tasks.stream().filter(TickTask::isRunning).forEach(TickTask::tick);
     }
 
     @Override
@@ -29,11 +29,11 @@ public class WorldTimerAccess implements TimerAccess {
 
     @Override
     public void dds_cancel() {
-        tasks.stream().filter(t -> !t.isCancelled()).forEach(TickTask::cancel);
+        tasks.stream().filter(TickTask::isRunning).forEach(TickTask::cancel);
     }
 
     @Override
     public List<TickTask> dds_getTasks() {
-        return tasks.stream().filter(t -> !t.isCancelled()).toList();
+        return tasks.stream().filter(TickTask::isRunning).toList();
     }
 }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/mixin/WorldTimerAccess.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/mixin/WorldTimerAccess.java
@@ -27,4 +27,9 @@ public class WorldTimerAccess implements TimerAccess {
     public void dds_runTask(TickTask task) {
         tasks.add(task);
     }
+
+    @Override
+    public void dds_cancel() {
+        tasks.forEach(TickTask::cancel);
+    }
 }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/mixin/WorldTimerAccess.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/mixin/WorldTimerAccess.java
@@ -19,7 +19,7 @@ public class WorldTimerAccess implements TimerAccess {
 
     @Inject(method = "tick", at = @At("TAIL"))
     private void onTick(BooleanSupplier shouldKeepTicking, CallbackInfo ci) {
-        tasks.forEach(TickTask::tick);
+        tasks.stream().filter(t -> !t.isCancelled()).forEach(TickTask::tick);
     }
 
     @Override

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/mixin/WorldTimerAccess.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/mixin/WorldTimerAccess.java
@@ -1,0 +1,30 @@
+package world.anhgelus.architectsland.difficultydeathscaler.mixin;
+
+import net.minecraft.server.world.ServerWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import world.anhgelus.architectsland.difficultydeathscaler.timer.TickTask;
+import world.anhgelus.architectsland.difficultydeathscaler.timer.TimerAccess;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+
+@Mixin(ServerWorld.class)
+public class WorldTimerAccess implements TimerAccess {
+    @Unique
+    private final List<TickTask> tasks = new ArrayList<>();
+
+    @Inject(method = "tick", at = @At("TAIL"))
+    private void onTick(BooleanSupplier shouldKeepTicking, CallbackInfo ci) {
+        tasks.forEach(TickTask::tick);
+    }
+
+    @Override
+    public void dds_runTask(TickTask task) {
+        tasks.add(task);
+    }
+}

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/mixin/WorldTimerAccess.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/mixin/WorldTimerAccess.java
@@ -6,7 +6,6 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import world.anhgelus.architectsland.difficultydeathscaler.timer.TickTask;
 import world.anhgelus.architectsland.difficultydeathscaler.timer.TimerAccess;
 
 import java.util.ArrayList;
@@ -16,7 +15,7 @@ import java.util.function.BooleanSupplier;
 @Mixin(ServerWorld.class)
 public class WorldTimerAccess implements TimerAccess {
     @Unique
-    private final List<TickTask> tasks = new ArrayList<>();
+    private final List<TimerAccess.TickTask> tasks = new ArrayList<>();
 
     @Inject(method = "tick", at = @At("TAIL"))
     private void onTick(BooleanSupplier shouldKeepTicking, CallbackInfo ci) {
@@ -24,12 +23,17 @@ public class WorldTimerAccess implements TimerAccess {
     }
 
     @Override
-    public void dds_runTask(TickTask task) {
+    public void dds_runTask(TimerAccess.TickTask task) {
         tasks.add(task);
     }
 
     @Override
     public void dds_cancel() {
-        tasks.forEach(TickTask::cancel);
+        tasks.stream().filter(t -> !t.isCancelled()).forEach(TickTask::cancel);
+    }
+
+    @Override
+    public List<TickTask> dds_getTasks() {
+        return tasks.stream().filter(t -> !t.isCancelled()).toList();
     }
 }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/mixin/WorldTimerAccess.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/mixin/WorldTimerAccess.java
@@ -17,14 +17,19 @@ public class WorldTimerAccess implements TimerAccess {
     @Unique
     private final List<TimerAccess.TickTask> tasks = new ArrayList<>();
 
+    @Unique
+    private final List<TimerAccess.TickTask> tasksToAdd = new ArrayList<>();
+
     @Inject(method = "tick", at = @At("TAIL"))
     private void onTick(BooleanSupplier shouldKeepTicking, CallbackInfo ci) {
         tasks.stream().filter(TickTask::isRunning).forEach(TickTask::tick);
+        tasks.addAll(tasksToAdd);
+        tasksToAdd.clear();
     }
 
     @Override
     public void dds_runTask(TimerAccess.TickTask task) {
-        tasks.add(task);
+        tasksToAdd.add(task);
     }
 
     @Override

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TickTask.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TickTask.java
@@ -14,21 +14,21 @@ public class TickTask {
 
     private boolean cancelled = false;
 
-    private final long ticksDelay;
-    private final long ticksRepeat;
-    private final boolean repeat;
-    private final Task task;
+    public final long ticksDelay;
+    public final long ticksRepeat;
+    public final boolean repeat;
+    public final Task task;
 
     private long currentTicking;
 
     /**
      * Create a new repeating TickTask
      *
+     * @param task        Task to run after the delay or the repeat time
      * @param ticksDelay  Delay before the first task's run
      * @param ticksRepeat Repeat each tick
-     * @param task        Task to run after the delay or the repeat time
      */
-    public TickTask(long ticksDelay, long ticksRepeat, Task task) {
+    public TickTask(Task task, long ticksDelay, long ticksRepeat) {
         this.ticksDelay = ticksDelay;
         this.ticksRepeat = ticksRepeat;
         this.task = task;
@@ -39,10 +39,10 @@ public class TickTask {
     /**
      * Create a new TickTask
      *
-     * @param ticksDelay Delay before the first task's run
      * @param task       Task to run after the delay or the repeat time
+     * @param ticksDelay Delay before the first task's run
      */
-    public TickTask(long ticksDelay, Task task) {
+    public TickTask(Task task, long ticksDelay) {
         this.ticksDelay = ticksDelay;
         this.ticksRepeat = -1;
         this.task = task;
@@ -75,13 +75,5 @@ public class TickTask {
 
     public boolean isCancelled() {
         return cancelled;
-    }
-
-    public long getTicksDelay() {
-        return ticksDelay;
-    }
-
-    public long getTicksRepeat() {
-        return ticksRepeat;
     }
 }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TickTask.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TickTask.java
@@ -8,7 +8,7 @@ public class TickTask implements TimerAccess.TickTask {
 
     public final long ticksDelay;
     public final long ticksRepeat;
-    public final boolean repeat;
+    public final boolean repeating;
     public final TimerAccess.Task task;
 
     private long currentTicking;
@@ -18,13 +18,13 @@ public class TickTask implements TimerAccess.TickTask {
      *
      * @param task        Task to run after the delay or the repeat time
      * @param ticksDelay  Delay before the first task's run
-     * @param ticksRepeat Repeat each tick
+     * @param ticksRepeat Repeat each tick (if the repeat is <= 0, it will repeat each tick)
      */
     public TickTask(TimerAccess.Task task, long ticksDelay, long ticksRepeat) {
         this.ticksDelay = ticksDelay;
         this.ticksRepeat = ticksRepeat;
         this.task = task;
-        repeat = true;
+        repeating = true;
         currentTicking = ticksDelay;
     }
 
@@ -38,7 +38,7 @@ public class TickTask implements TimerAccess.TickTask {
         this.ticksDelay = ticksDelay;
         this.ticksRepeat = -1;
         this.task = task;
-        repeat = false;
+        repeating = false;
         currentTicking = ticksDelay;
     }
 
@@ -46,9 +46,9 @@ public class TickTask implements TimerAccess.TickTask {
      * Tick the task
      */
     public void tick() {
-        if (--currentTicking != 0) return;
+        if (--currentTicking > 0) return;
         task.run();
-        if (repeat) {
+        if (repeating) {
             currentTicking = ticksRepeat;
         } else {
             cancel();

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TickTask.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TickTask.java
@@ -1,0 +1,87 @@
+package world.anhgelus.architectsland.difficultydeathscaler.timer;
+
+/**
+ * Represents a complete task called each tick
+ */
+public class TickTask {
+    /**
+     * Represents a task to run after ticking
+     */
+    @FunctionalInterface
+    public interface Task {
+        void run();
+    }
+
+    private boolean cancelled = false;
+
+    private final long ticksDelay;
+    private final long ticksRepeat;
+    private final boolean repeat;
+    private final Task task;
+
+    private long currentTicking;
+
+    /**
+     * Create a new repeating TickTask
+     *
+     * @param ticksDelay  Delay before the first task's run
+     * @param ticksRepeat Repeat each tick
+     * @param task        Task to run after the delay or the repeat time
+     */
+    public TickTask(long ticksDelay, long ticksRepeat, Task task) {
+        this.ticksDelay = ticksDelay;
+        this.ticksRepeat = ticksRepeat;
+        this.task = task;
+        repeat = true;
+        currentTicking = ticksDelay;
+    }
+
+    /**
+     * Create a new TickTask
+     *
+     * @param ticksDelay Delay before the first task's run
+     * @param task       Task to run after the delay or the repeat time
+     */
+    public TickTask(long ticksDelay, Task task) {
+        this.ticksDelay = ticksDelay;
+        this.ticksRepeat = -1;
+        this.task = task;
+        repeat = false;
+        currentTicking = ticksDelay;
+    }
+
+    /**
+     * Tick the task
+     */
+    public void tick() {
+        if (--currentTicking != 0) return;
+        task.run();
+        if (repeat) {
+            currentTicking = ticksRepeat;
+        } else {
+            cancel();
+        }
+    }
+
+    /**
+     * Cancel the task
+     *
+     * @return the remaining ticks before the run of the Task
+     */
+    public long cancel() {
+        cancelled = true;
+        return currentTicking;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public long getTicksDelay() {
+        return ticksDelay;
+    }
+
+    public long getTicksRepeat() {
+        return ticksRepeat;
+    }
+}

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TickTask.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TickTask.java
@@ -58,8 +58,8 @@ public class TickTask implements TimerAccess.TickTask {
         return currentTicking;
     }
 
-    public boolean isCancelled() {
-        return cancelled;
+    public boolean isRunning() {
+        return !cancelled;
     }
 
     @Override

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TickTask.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TickTask.java
@@ -42,9 +42,6 @@ public class TickTask implements TimerAccess.TickTask {
         currentTicking = ticksDelay;
     }
 
-    /**
-     * Tick the task
-     */
     public void tick() {
         if (--currentTicking > 0) return;
         task.run();
@@ -55,12 +52,6 @@ public class TickTask implements TimerAccess.TickTask {
         }
     }
 
-    /**
-     * Cancel the task
-     *
-     * @return the remaining ticks before the run of the Task
-     * @throws IllegalStateException if the task is already cancelled
-     */
     public long cancel() {
         if (cancelled) throw new IllegalStateException("Task already cancelled");
         cancelled = true;
@@ -69,5 +60,11 @@ public class TickTask implements TimerAccess.TickTask {
 
     public boolean isCancelled() {
         return cancelled;
+    }
+
+    @Override
+    public long getTickingBeforeRun() {
+        if (cancelled) return -1;
+        return currentTicking;
     }
 }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TickTask.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TickTask.java
@@ -18,23 +18,27 @@ public class TickTask implements TimerAccess.TickTask {
      *
      * @param task        Task to run after the delay or the repeat time
      * @param ticksDelay  Delay before the first task's run
-     * @param ticksRepeat Repeat each tick (if the repeat is <= 0, it will repeat each tick)
+     * @param ticksRepeat Repeat each tick (if the repeat is 0, it will repeat each tick, if it is below 0, it will not repeat)
+     * @throws IllegalArgumentException if ticksDelay is below 0
      */
     public TickTask(TimerAccess.Task task, long ticksDelay, long ticksRepeat) {
+        if (ticksDelay < 0) throw new IllegalArgumentException("Ticks delay must be non-negative");
         this.ticksDelay = ticksDelay;
         this.ticksRepeat = ticksRepeat;
         this.task = task;
-        repeating = true;
+        repeating = ticksRepeat >= 0;
         currentTicking = ticksDelay;
     }
 
     /**
-     * Create a new TickTask
+     * Create a new delayed TickTask
      *
      * @param task       Task to run after the delay or the repeat time
      * @param ticksDelay Delay before the first task's run
+     * @throws IllegalArgumentException if ticksDelay or if ticksRepeat is below 0
      */
     public TickTask(TimerAccess.Task task, long ticksDelay) {
+        if (ticksDelay < 0) throw new IllegalArgumentException("Ticks delay must be non-negative");
         this.ticksDelay = ticksDelay;
         this.ticksRepeat = -1;
         this.task = task;

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TickTask.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TickTask.java
@@ -3,21 +3,13 @@ package world.anhgelus.architectsland.difficultydeathscaler.timer;
 /**
  * Represents a complete task called each tick
  */
-public class TickTask {
-    /**
-     * Represents a task to run after ticking
-     */
-    @FunctionalInterface
-    public interface Task {
-        void run();
-    }
-
+public class TickTask implements TimerAccess.TickTask {
     private boolean cancelled = false;
 
     public final long ticksDelay;
     public final long ticksRepeat;
     public final boolean repeat;
-    public final Task task;
+    public final TimerAccess.Task task;
 
     private long currentTicking;
 
@@ -28,7 +20,7 @@ public class TickTask {
      * @param ticksDelay  Delay before the first task's run
      * @param ticksRepeat Repeat each tick
      */
-    public TickTask(Task task, long ticksDelay, long ticksRepeat) {
+    public TickTask(TimerAccess.Task task, long ticksDelay, long ticksRepeat) {
         this.ticksDelay = ticksDelay;
         this.ticksRepeat = ticksRepeat;
         this.task = task;
@@ -42,7 +34,7 @@ public class TickTask {
      * @param task       Task to run after the delay or the repeat time
      * @param ticksDelay Delay before the first task's run
      */
-    public TickTask(Task task, long ticksDelay) {
+    public TickTask(TimerAccess.Task task, long ticksDelay) {
         this.ticksDelay = ticksDelay;
         this.ticksRepeat = -1;
         this.task = task;
@@ -67,8 +59,10 @@ public class TickTask {
      * Cancel the task
      *
      * @return the remaining ticks before the run of the Task
+     * @throws IllegalStateException if the task is already cancelled
      */
     public long cancel() {
+        if (cancelled) throw new IllegalStateException("Task already cancelled");
         cancelled = true;
         return currentTicking;
     }

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TimerAccess.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TimerAccess.java
@@ -11,6 +11,8 @@ public interface TimerAccess {
      */
     void dds_runTask(TickTask task);
 
+    void dds_cancel();
+
     /**
      * Get the timer linked to the overworld
      *

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TimerAccess.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TimerAccess.java
@@ -7,11 +7,25 @@ import java.util.List;
 
 public interface TimerAccess {
     interface TickTask {
+        /**
+         * Tick the task
+         */
         void tick();
 
+        /**
+         * Cancel the task
+         *
+         * @return the remaining ticks before the run of the Task
+         * @throws IllegalStateException if the task is already cancelled
+         */
         long cancel();
 
         boolean isCancelled();
+
+        /**
+         * @return the number of ticks before run of the task (if the task is cancelled, returns -1)
+         */
+        long getTickingBeforeRun();
     }
 
     /**

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TimerAccess.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TimerAccess.java
@@ -20,7 +20,7 @@ public interface TimerAccess {
          */
         long cancel();
 
-        boolean isCancelled();
+        boolean isRunning();
 
         /**
          * @return the number of ticks before run of the task (if the task is cancelled, returns -1)

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TimerAccess.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TimerAccess.java
@@ -3,15 +3,38 @@ package world.anhgelus.architectsland.difficultydeathscaler.timer;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.World;
 
+import java.util.List;
+
 public interface TimerAccess {
+    interface TickTask {
+        void tick();
+
+        long cancel();
+
+        boolean isCancelled();
+    }
+
+    /**
+     * Represents a task to run after ticking
+     */
+    @FunctionalInterface
+    interface Task {
+        void run();
+    }
+
     /**
      * Run a task (called each tick ticked)
      *
      * @param task Task to run
      */
-    void dds_runTask(TickTask task);
+    void dds_runTask(TimerAccess.TickTask task);
 
     void dds_cancel();
+
+    /**
+     * @return All non-cancelled tasks
+     */
+    List<TickTask> dds_getTasks();
 
     /**
      * Get the timer linked to the overworld

--- a/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TimerAccess.java
+++ b/src/main/java/world/anhgelus/architectsland/difficultydeathscaler/timer/TimerAccess.java
@@ -1,0 +1,26 @@
+package world.anhgelus.architectsland.difficultydeathscaler.timer;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.World;
+
+public interface TimerAccess {
+    /**
+     * Run a task (called each tick ticked)
+     *
+     * @param task Task to run
+     */
+    void dds_runTask(TickTask task);
+
+    /**
+     * Get the timer linked to the overworld
+     *
+     * @param server Current server
+     * @return TimerAccess linked to the overworld
+     */
+    static TimerAccess getTimerFromOverworld(MinecraftServer server) {
+        final var timer = (TimerAccess) server.getWorld(World.OVERWORLD);
+        if (timer == null)
+            throw new NullPointerException("Impossible to get TimerAccess from the overworld (it is null)");
+        return timer;
+    }
+}

--- a/src/main/resources/difficultydeathscaler.mixins.json
+++ b/src/main/resources/difficultydeathscaler.mixins.json
@@ -10,7 +10,8 @@
     "AnnoyingMobEntity",
     "AnnoyingSkeleton",
     "AnnoyingZombie",
-    "PlayerManagerMixin"
+    "PlayerManagerMixin",
+    "WorldTimerAccess"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
These custom timers are located inside tickable things like `ServerWorld` and they are represented by `TimerAccess`. They contain `TickTask` that are called each tick. The repetition, the delay, and the cancellation are managed by the task and not the timer.

This remove complexity because we do not manage the timer: everything is managed by Mojang's stuff. For example, we do not have to cancel the timer.

In addition to this, the timers stop ticking when the server is paused: the time is *in game* time and not *server available* time.